### PR TITLE
Expose JSON error message from failed API calls

### DIFF
--- a/environment_manager/api.py
+++ b/environment_manager/api.py
@@ -96,7 +96,7 @@ class EMApi(object):
             if int(str(request.status_code)[:1]) == 2:
                 return request.json()
             elif int(str(request.status_code)[:1]) == 4 or int(str(request.status_code)[:1]) == 5:
-                raise ValueError(request.json()['originalException']['message'])
+                raise ValueError(request.json()['error'])
             else:
                 log.info('Got a status %s from EM, cant serve, retrying' % request.status_code)
                 log.debug(request.request.headers)


### PR DESCRIPTION
A small fix to properly expose the error content from 4XX responses.