### PR TITLE
Handle non-JSON responses

### DIFF
--- a/environment_manager/api.py
+++ b/environment_manager/api.py
@@ -94,9 +94,16 @@ class EMApi(object):
             else:
                 raise SyntaxError('Cannot process query type %s' % query_type)
             if int(str(request.status_code)[:1]) == 2:
-                return request.json()
+                try:
+                    return request.json()
+                except ValueError:
+                    return request.text
             elif int(str(request.status_code)[:1]) == 4 or int(str(request.status_code)[:1]) == 5:
-                raise ValueError(request.json()['error'])
+                try:
+                    error_msg = request.json()['error']
+                except:
+                    error_msg = "An unknown error occured"
+                raise ValueError(error_msg)
             else:
                 log.info('Got a status %s from EM, cant serve, retrying' % request.status_code)
                 log.debug(request.request.headers)


### PR DESCRIPTION
There is currently an issue in Environment Manager where a very small set of API responses are returned as plain strings instead of JSON objects. These will cause our `request.json()` handlers to raise an error.

As there are other client libraries that have grown to expect this non-json "feature" in Environment Manager, the fix involves updating several projects at once. To facilitate that, this change temporarily adds support for both JSON and plain text responses.