### PR TITLE
Add default headers option in constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build
 dist
 *.egg-info
 *.pyc
+*.swp
+*swo


### PR DESCRIPTION
This change allows a set of default header values to be passed to an `EMApi` constructor, which will be used for all subsequent requests (for example if you to supply a `User-Agent` string for all calls via the library)