### PR TITLE
Allow environment and cluster params for instances requests

### DIFF
--- a/environment_manager/api.py
+++ b/environment_manager/api.py
@@ -533,9 +533,16 @@ class EMApi(object):
         return self.query(query_endpoint=request_endpoint, query_type='PUT', data=data, **kwargs)
 
     ## Instance
-    def get_instances(self, **kwargs):
+    def get_instances(self, environment=None, cluster=None, **kwargs):
         """ Get all instances matching the given criteria """
         request_endpoint = '/api/v1/instances'
+        queries = []
+        if environment is not None:
+            queries.append('environment={0}'.format(environment))
+        if cluster is not None:
+            queries.append('cluster={0}'.format(cluster))
+        if queries:
+            request_endpoint += '?{0}'.format('&'.join(queries))
         return self.query(query_endpoint=request_endpoint, query_type='GET', **kwargs)
 
     def get_instance(self, instance_id=None, **kwargs):


### PR DESCRIPTION
Adds support for `environment` and `cluster` filters when requesting a list of instances.