### PR TITLE
Handle responses with multiple errors

### DIFF
--- a/environment_manager/api.py
+++ b/environment_manager/api.py
@@ -101,7 +101,10 @@ class EMApi(object):
                 try:
                     error_msg = request.json()['error']
                 except:
-                    error_msg = "An unknown error occured"
+                    try:
+                        error_msg = request.json()['errors']
+                    except:
+                        error_msg = 'An unknown error occured'
                 raise ValueError(error_msg)
             else:
                 log.info('Got a status %s from EM, cant serve, retrying' % request.status_code)


### PR DESCRIPTION
The endpoint for retrieving package upload paths erroneously returns an `errors` object instead of the expected `error` item. Until this is fixed in Environment Manager, this fix will handle both cases.