### PR TITLE
Reusing auth token, handling connection exceptions

### DIFF
--- a/environment_manager/api.py
+++ b/environment_manager/api.py
@@ -54,6 +54,7 @@ class EMApi(object):
                     time.sleep(2)
             except (ConnectionError, Timeout) as e:
                 log.debug('There was a problem with the connection, trying again; error = %s' % e)
+                time.sleep(2)
         if token is not None:
             # Got token now lets get URL
             token_bearer = 'Bearer %s' % token


### PR DESCRIPTION
I've noticed that sometimes, when waiting for deployments to complete the library will crash if there is a connection error, so this code is to handle it and retry (similar in the way it handles other errors) 
Currently for each EM call we re-authenticate, I don't think this is necessary so I've added reusing the token until it's expiration.